### PR TITLE
Make generated course outline editable in UI

### DIFF
--- a/app/display_content.py
+++ b/app/display_content.py
@@ -1,0 +1,188 @@
+import streamlit as st
+from typing import Dict, Any
+
+ss = st.session_state
+
+def _get_outline_node(path_parts):
+    """Return the container and final key/index for a dotted outline path."""
+    if "generated_outline" not in ss:
+        raise KeyError("Outline is not available in session state.")
+
+    if not path_parts:
+        raise ValueError("Path cannot be empty.")
+
+    node: Any = ss["generated_outline"]
+    for idx, part in enumerate(path_parts[:-1]):
+        next_part = path_parts[idx + 1]
+        if isinstance(node, list):
+            index = int(part)
+            node = node[index]
+        elif isinstance(node, dict):
+            if part not in node:
+                node[part] = [] if next_part.isdigit() else {}
+            node = node[part]
+        else:
+            raise KeyError(f"Unsupported path segment '{part}' for node type {type(node)}")
+
+    return node, path_parts[-1]
+
+def _normalize_outline_input(path: str, raw_value: str, existing: Any):
+    if isinstance(existing, list) or path.endswith("keyPoints"):
+        lines = [line.strip() for line in (raw_value or "").splitlines()]
+        return [line for line in lines if line]
+    return raw_value
+
+def _update_outline_value(path: str, widget_key: str):
+    if "generated_outline" not in ss:
+        return
+
+    raw_value = ss.get(widget_key, "")
+    path_parts = path.split(".")
+    parent, final_key = _get_outline_node(path_parts)
+
+    if isinstance(parent, list):
+        index = int(final_key)
+        existing = parent[index] if index < len(parent) else None
+        normalized = _normalize_outline_input(path, raw_value, existing)
+        if index < len(parent):
+            parent[index] = normalized
+        else:
+            parent.append(normalized)
+    else:
+        existing = parent.get(final_key)
+        normalized = _normalize_outline_input(path, raw_value, existing)
+        parent[final_key] = normalized
+
+    ss[widget_key] = "\n".join(normalized) if isinstance(normalized, list) else normalized
+
+def outline_text_field(label: str, path: str, value: Any, *, area: bool = False):
+    widget_key = f"outline__{path.replace('.', '__')}"
+
+    if isinstance(value, list):
+        initial_value = "\n".join(value)
+    else:
+        initial_value = value or ""
+
+    if widget_key not in ss:
+        ss[widget_key] = initial_value
+
+    field_kwargs = {
+        "label": label,
+        "key": widget_key,
+        "on_change": _update_outline_value,
+        "args": (path, widget_key),
+    }
+
+    if area:
+        st.text_area(**field_kwargs)
+    else:
+        st.text_input(**field_kwargs)
+
+
+
+def display_editable_outline(outline: Dict[str, Any]):
+    """Render the editable outline using text inputs backed by session state."""
+
+    outline.setdefault("courseLevelObjectives", [])
+    outline.setdefault("modules", [])
+
+    st.header("Course Title")
+    outline_text_field("Title", "courseTitle", outline.get("courseTitle", ""))
+
+    st.markdown("**Course-Level Objectives**")
+    outline_text_field("Objectives (one per line)", "courseLevelObjectives", 
+                        "\n".join(outline.get("courseLevelObjectives", [])), area=True)
+
+
+    st.divider()
+
+    for module_index, module in enumerate(outline["modules"]):
+        module.setdefault("sections", [])
+        st.subheader(f"Module {module_index + 1}")
+        outline_text_field(
+            "Module title",
+            f"modules.{module_index}.moduleTitle",
+            module.get("moduleTitle", ""),
+        )
+        outline_text_field(
+            "Module overview",
+            f"modules.{module_index}.overview",
+            module.get("overview", ""),
+            area=True,
+        )
+
+        for section_index, section in enumerate(module["sections"]):
+            section.setdefault("sectionLevelObjectives", [])
+            section.setdefault("units", [])
+
+            st.markdown(f"#### Section {section_index + 1}")
+            outline_text_field(
+                "Section title",
+                f"modules.{module_index}.sections.{section_index}.sectionTitle",
+                section.get("sectionTitle", ""),
+            )
+
+            outline_text_field(
+                "Section objectives (one per line)",
+                f"modules.{module_index}.sections.{section_index}.sectionLevelObjectives",
+                "\n".join(section.get("sectionLevelObjectives", [])),
+                area=True,
+            )
+
+            for unit_index, unit in enumerate(section["units"]):
+                unit.setdefault("unitLevelObjective", {})
+                unit.setdefault("keyPoints", [])
+
+                with st.expander(
+                    f"Unit {section_index + 1}.{unit_index + 1}: {unit.get('unitTitle', 'Untitled unit') or 'Untitled unit'}",
+                    expanded=False,
+                ):
+                    outline_text_field(
+                        "Unit title",
+                        f"modules.{module_index}.sections.{section_index}.units.{unit_index}.unitTitle",
+                        unit.get("unitTitle", ""),
+                    )
+
+                    outline_text_field(
+                        "Unit objective",
+                        f"modules.{module_index}.sections.{section_index}.units.{unit_index}.unitLevelObjective",
+                        unit.get("unitLevelObjective", "")
+                    )
+
+                    outline_text_field(
+                        "Key points (one per line)",
+                        f"modules.{module_index}.sections.{section_index}.units.{unit_index}.keyPoints",
+                        "\n".join(unit.get("keyPoints", [])),
+                        area=True,
+                    )
+
+def display_static_outline(outline: Dict[str, Any]):
+        """
+        Parses the JSON outline and displays it in a user-friendly format.
+        LLM output was already converted to Python dict in generate_outline().
+        """
+        st.header(f"Title: {outline.get('courseTitle', 'N/A')}")
+
+        st.markdown("**Course-Level Objectives**")
+        for obj in outline.get("courseLevelObjectives", []):
+            st.markdown(f"- {obj}")
+
+        st.markdown("---")
+
+        for i, module in enumerate(outline.get("modules", [])):
+            st.subheader(f"Module {i+1}: {module.get('moduleTitle', 'N/A')}")        
+            st.markdown(f"**Overview:** {module.get('overview', 'N/A')}")
+            
+            for j, section in enumerate(module.get("sections", [])):
+                st.markdown(f"#### Section {j+1}: {section.get('sectionTitle', 'N/A')}")
+                
+                for s_obj in section.get("sectionLevelObjectives", []):
+                    st.markdown(f"_{s_obj}_")
+
+                for k, unit in enumerate(section.get("units", [])):
+                    with st.expander(f"**Unit {j+1}.{k+1}: {unit.get('unitTitle', 'N/A')}**", expanded=False):
+                        #unit_obj = unit.get("unitLevelObjective", {})
+                        st.markdown(f"_**Objective:** {unit.get("unitLevelObjective", 'N/A')}_")
+                        st.markdown("**Key Points:**")
+                        for point in unit.get("keyPoints", []):
+                            st.markdown(f"  - {point}")

--- a/mainapp.py
+++ b/mainapp.py
@@ -317,36 +317,189 @@ Investing time upfront in the outline will make the presentation of content more
         with st.spinner("Analyzing documents and generating outline... This may take a moment."):
             ss['generated_outline'] = generate_outline(ss["outline_guidance"].strip(), ss["course_text"])
 
+    def _get_outline_node(path_parts):
+        """Return the container and final key/index for a dotted outline path."""
+        if "generated_outline" not in ss:
+            raise KeyError("Outline is not available in session state.")
+
+        if not path_parts:
+            raise ValueError("Path cannot be empty.")
+
+        node: Any = ss["generated_outline"]
+        for idx, part in enumerate(path_parts[:-1]):
+            next_part = path_parts[idx + 1]
+            if isinstance(node, list):
+                index = int(part)
+                node = node[index]
+            elif isinstance(node, dict):
+                if part not in node:
+                    node[part] = [] if next_part.isdigit() else {}
+                node = node[part]
+            else:
+                raise KeyError(f"Unsupported path segment '{part}' for node type {type(node)}")
+
+        return node, path_parts[-1]
+
+    def _normalize_outline_input(path: str, raw_value: str, existing: Any):
+        if isinstance(existing, list) or path.endswith("keyPoints"):
+            lines = [line.strip() for line in (raw_value or "").splitlines()]
+            return [line for line in lines if line]
+        return raw_value
+
+    def _update_outline_value(path: str, widget_key: str):
+        if "generated_outline" not in ss:
+            return
+
+        raw_value = ss.get(widget_key, "")
+        path_parts = path.split(".")
+        parent, final_key = _get_outline_node(path_parts)
+
+        if isinstance(parent, list):
+            index = int(final_key)
+            existing = parent[index] if index < len(parent) else None
+            normalized = _normalize_outline_input(path, raw_value, existing)
+            if index < len(parent):
+                parent[index] = normalized
+            else:
+                parent.append(normalized)
+        else:
+            existing = parent.get(final_key)
+            normalized = _normalize_outline_input(path, raw_value, existing)
+            parent[final_key] = normalized
+
+        ss[widget_key] = "\n".join(normalized) if isinstance(normalized, list) else normalized
+
+    def outline_text_field(label: str, path: str, value: Any, *, area: bool = False):
+        widget_key = f"outline__{path.replace('.', '__')}"
+
+        if isinstance(value, list):
+            initial_value = "\n".join(value)
+        else:
+            initial_value = value or ""
+
+        if widget_key not in ss:
+            ss[widget_key] = initial_value
+
+        field_kwargs = {
+            "label": label,
+            "key": widget_key,
+            "on_change": _update_outline_value,
+            "args": (path, widget_key),
+        }
+
+        if area:
+            st.text_area(**field_kwargs)
+        else:
+            st.text_input(**field_kwargs)
+
     def display_outline(outline: Dict[str, Any]):
-        """
-        Parses the JSON outline and displays it in a user-friendly format.
-        LLM output was already converted to Python dict in generate_outline().
-        """
-        st.header(f"Title: {outline.get('courseTitle', 'N/A')}")
+        """Render the editable outline using text inputs backed by session state."""
 
-        st.markdown("**Course-Level Objectives**")
-        for obj in outline.get("courseLevelObjectives", []):
-            st.markdown(f"- {obj}")
+        outline.setdefault("courseLevelObjectives", [])
+        outline.setdefault("modules", [])
 
-        st.markdown("---")
+        st.header("Course Outline")
+        outline_text_field("Course title", "courseTitle", outline.get("courseTitle", ""))
 
-        for i, module in enumerate(outline.get("modules", [])):
-            st.subheader(f"Module {i+1}: {module.get('moduleTitle', 'N/A')}")        
-            st.markdown(f"**Overview:** {module.get('overview', 'N/A')}")
-            
-            for j, section in enumerate(module.get("sections", [])):
-                st.markdown(f"#### Section {j+1}: {section.get('sectionTitle', 'N/A')}")
-                
-                for s_obj in section.get("sectionLevelObjectives", []):
-                    st.markdown(f"_**({s_obj.get('bloomsLevel', 'N/A')})**: {s_obj.get('objectiveText', 'N/A')}_")
+        st.subheader("Course-Level Objectives")
+        course_objectives = outline["courseLevelObjectives"]
+        for idx, objective in enumerate(course_objectives):
+            outline_text_field(f"Objective {idx + 1}", f"courseLevelObjectives.{idx}", objective)
 
-                for k, unit in enumerate(section.get("units", [])):
-                    with st.expander(f"**Unit {j+1}.{k+1}: {unit.get('unitTitle', 'N/A')}**", expanded=False):
-                        unit_obj = unit.get("unitLevelObjective", {})
-                        st.markdown(f"_**Objective ({unit_obj.get('bloomsLevel', 'N/A')}):** {unit_obj.get('objectiveText', 'N/A')}_")
-                        st.markdown("**Key Points:**")
-                        for point in unit.get("keyPoints", []):
-                            st.markdown(f"  - {point}")
+        if st.button("Add course objective", key="outline_add_course_objective"):
+            course_objectives.append("")
+            new_path = f"courseLevelObjectives.{len(course_objectives) - 1}"
+            ss[f"outline__{new_path.replace('.', '__')}"] = ""
+            st.rerun()
+
+        st.divider()
+
+        for module_index, module in enumerate(outline["modules"]):
+            module.setdefault("sections", [])
+            st.markdown(f"### Module {module_index + 1}")
+            outline_text_field(
+                "Module title",
+                f"modules.{module_index}.moduleTitle",
+                module.get("moduleTitle", ""),
+            )
+            outline_text_field(
+                "Module overview",
+                f"modules.{module_index}.overview",
+                module.get("overview", ""),
+                area=True,
+            )
+
+            for section_index, section in enumerate(module["sections"]):
+                section.setdefault("sectionLevelObjectives", [])
+                section.setdefault("units", [])
+
+                st.markdown(f"#### Section {module_index + 1}.{section_index + 1}")
+                outline_text_field(
+                    "Section title",
+                    f"modules.{module_index}.sections.{section_index}.sectionTitle",
+                    section.get("sectionTitle", ""),
+                )
+
+                st.caption("Section-level objectives")
+                for obj_index, section_obj in enumerate(section["sectionLevelObjectives"]):
+                    cols = st.columns([1, 3])
+                    with cols[0]:
+                        outline_text_field(
+                            "Bloom level",
+                            f"modules.{module_index}.sections.{section_index}.sectionLevelObjectives.{obj_index}.bloomsLevel",
+                            section_obj.get("bloomsLevel", ""),
+                        )
+                    with cols[1]:
+                        outline_text_field(
+                            "Objective text",
+                            f"modules.{module_index}.sections.{section_index}.sectionLevelObjectives.{obj_index}.objectiveText",
+                            section_obj.get("objectiveText", ""),
+                            area=True,
+                        )
+
+                add_section_obj_key = f"outline_add_section_obj_{module_index}_{section_index}"
+                if st.button("Add section objective", key=add_section_obj_key):
+                    section["sectionLevelObjectives"].append({"bloomsLevel": "", "objectiveText": ""})
+                    base_path = f"modules.{module_index}.sections.{section_index}.sectionLevelObjectives.{len(section['sectionLevelObjectives']) - 1}"
+                    ss[f"outline__{base_path.replace('.', '__') + '__bloomsLevel'}"] = ""
+                    ss[f"outline__{base_path.replace('.', '__') + '__objectiveText'}"] = ""
+                    st.rerun()
+
+                for unit_index, unit in enumerate(section["units"]):
+                    unit.setdefault("unitLevelObjective", {})
+                    unit.setdefault("keyPoints", [])
+
+                    with st.expander(
+                        f"Unit {module_index + 1}.{section_index + 1}.{unit_index + 1}: {unit.get('unitTitle', 'Untitled unit') or 'Untitled unit'}",
+                        expanded=False,
+                    ):
+                        outline_text_field(
+                            "Unit title",
+                            f"modules.{module_index}.sections.{section_index}.units.{unit_index}.unitTitle",
+                            unit.get("unitTitle", ""),
+                        )
+
+                        cols = st.columns([1, 3])
+                        with cols[0]:
+                            outline_text_field(
+                                "Bloom level",
+                                f"modules.{module_index}.sections.{section_index}.units.{unit_index}.unitLevelObjective.bloomsLevel",
+                                unit["unitLevelObjective"].get("bloomsLevel", ""),
+                            )
+                        with cols[1]:
+                            outline_text_field(
+                                "Objective text",
+                                f"modules.{module_index}.sections.{section_index}.units.{unit_index}.unitLevelObjective.objectiveText",
+                                unit["unitLevelObjective"].get("objectiveText", ""),
+                                area=True,
+                            )
+
+                        outline_text_field(
+                            "Key points",
+                            f"modules.{module_index}.sections.{section_index}.units.{unit_index}.keyPoints",
+                            "\n".join(unit.get("keyPoints", [])),
+                            area=True,
+                        )
 
     # --- Display Output ---
     if 'generated_outline' in ss:

--- a/requirements copy.txt
+++ b/requirements copy.txt
@@ -1,8 +1,0 @@
-streamlit
-pypdf
-mammoth
-python-pptx
-python-docx
-python-dotenv
-tiktoken
-openai>=1.0.0


### PR DESCRIPTION
## Summary
- add helper utilities that keep outline edits in sync with `st.session_state['generated_outline']`
- render course, module, section, and unit fields as editable text inputs backed by the helper utilities
- allow adding blank course- and section-level objectives directly from the editor

## Testing
- python -m compileall mainapp.py

------
https://chatgpt.com/codex/tasks/task_e_68e08e04d0a48328a967194241f6494f