### PR TITLE
Add exponential backoff + jitter for OpenAI API retries

### DIFF
--- a/app/generate_llm_output.py
+++ b/app/generate_llm_output.py
@@ -3,6 +3,7 @@ import os
 import msal
 import json
 import random
+import backoff
 import streamlit as st
 from openai import OpenAI
 from typing import Dict, Any
@@ -248,6 +249,64 @@ def _collect_exception_debug(exc: Exception) -> Dict[str, Any]:
     return debug
 
 
+def _is_retryable_api_error(exc: Exception) -> bool:
+    """Return True when the OpenAI error is transient and should be retried."""
+    retryable_status_codes = {408, 409, 429, 500, 502, 503, 504}
+    status_code = _safe_attr(exc, "status_code")
+    if status_code in retryable_status_codes:
+        return True
+
+    exception_type = type(exc).__name__
+    retryable_exception_types = {
+        "RateLimitError",
+        "APIConnectionError",
+        "APITimeoutError",
+        "InternalServerError",
+    }
+    if exception_type in retryable_exception_types:
+        return True
+
+    body = _to_debug_primitive(_safe_attr(exc, "body"))
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, dict):
+            code = error.get("code")
+            if isinstance(code, str) and code.lower() in {
+                "rate_limit_exceeded",
+                "too_many_requests",
+            }:
+                return True
+
+    return False
+
+
+@backoff.on_exception(
+    backoff.expo,
+    Exception,
+    jitter=backoff.full_jitter,
+    max_tries=6,
+    giveup=lambda exc: not _is_retryable_api_error(exc),
+)
+def _create_response_with_backoff(client: OpenAI, model: str, system: str, user: str, max_tokens: int) -> Any:
+    """Call Responses API with exponential backoff + jitter for transient failures."""
+    return client.responses.create(  # type: ignore
+        model=model,
+        input=[
+            {
+                "role": "system",
+                "content": [{"type": "input_text", "text": system}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": user}],
+            },
+        ],
+        #temperature=temperature,
+        text={"format": {"type": "json_object"}},
+        max_output_tokens=max_tokens,
+    )
+
+
 def _chat_json(system:str, user:str, max_tokens:int, temperature:float)->Dict[str,Any]:
     if _is_mock_mode():
         return {"mock":"on"}
@@ -255,21 +314,12 @@ def _chat_json(system:str, user:str, max_tokens:int, temperature:float)->Dict[st
     model = _get_model()
     requested_max_tokens = max_tokens if model == "gpt-4.1" else max_tokens + TOKEN_BUFFER # add buffer for reasoning models
     try:
-        resp = client.responses.create( # type: ignore
+        resp = _create_response_with_backoff(
+            client=client,
             model=model,
-            input=[
-                {
-                    "role": "system",
-                    "content": [{"type": "input_text", "text": system}],
-                },
-                {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": user}],
-                },
-            ],
-            #temperature=temperature,
-            text={"format": {"type": "json_object"}},
-            max_output_tokens=requested_max_tokens,
+            system=system,
+            user=user,
+            max_tokens=requested_max_tokens,
         )
     except Exception as e:
         exception_debug = _collect_exception_debug(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ altair==5.5.0
 annotated-types==0.7.0
 anyio==4.10.0
 attrs==25.3.0
+backoff==2.2.1
 blinker==1.9.0
 cachetools==6.2.0
 certifi==2025.8.3


### PR DESCRIPTION
### Motivation
- Improve resilience when the OpenAI Responses API returns transient failures (rate limits, timeouts, or server errors) so the app can recover automatically instead of surfacing immediate failures to users.
- Use exponential backoff with jitter to reduce collision risk and avoid retry storms after Token-Per-Minute (TPM) or rate-limit events.

### Description
- Added `backoff` to `requirements.txt` and imported it in `app/generate_llm_output.py` to enable retry logic via the library.
- Implemented `_is_retryable_api_error` which classifies transient errors by HTTP status codes, common SDK exception type names, and error body codes such as `rate_limit_exceeded` or `too_many_requests`.
- Added `_create_response_with_backoff` that wraps the Responses API call with `@backoff.on_exception(backoff.expo, ..., jitter=backoff.full_jitter, max_tries=6, giveup=...)` to perform exponential backoff with full jitter and bounded retries.
- Updated `_chat_json` to call the new retry-enabled `_create_response_with_backoff` while preserving existing error collection and response parsing/debug behavior.

### Testing
- Ran `python -m compileall app` to compile the package files for syntax errors, and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d5a685348328b5f2f6901109a740)